### PR TITLE
"Dynamic" import of Redis

### DIFF
--- a/peeringdb/PeeringDB.py
+++ b/peeringdb/PeeringDB.py
@@ -15,7 +15,14 @@
 import urllib2
 import json
 import time
-from redis import Redis
+
+class MockRedis:
+    def __init__(self, **kwargs):
+        raise NotImplementedError("Redis is not installed but is required for caching. Install it or disable caching")
+try:
+    from redis import Redis
+except ImportError:
+    Redis = MockRedis
 
 
 class PeeringDB:
@@ -30,7 +37,8 @@ class PeeringDB:
         self.cache_enable = cache
         self.cache_ttl = cache_ttl
         self.cache_prefix = cache_prefix
-        self.redis = Redis(host=cache_host, port=cache_port, db=cache_db)
+        if cache:
+            self.redis = Redis(host=cache_host, port=cache_port, db=cache_db)
         return
 
     def pdb_get(self, param, cache=True):


### PR DESCRIPTION
If Redis is available on the system it is imported while if it is not,
we use a MockRedis class. Redis is used for caching so without we cannot
have caching enabled.

This allows you to use peeringdb on a machine without Redis as long as
caching is disabled while on a machine with Redis, caching can be used
as normally.

Not sure if it's a good idea or not. We could just add a dependency on Redis
instead but it is kind of nice to have 0 dependencies.